### PR TITLE
Add Strava OAuth and leaderboard API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+FRONTEND_BASE_URL=http://localhost:5173
+CORS_ALLOWED_ORIGINS=http://localhost:5173
+STRAVA_CLIENT_ID=your-strava-client-id
+STRAVA_CLIENT_SECRET=your-strava-client-secret
+STRAVA_COOKIE_SIGNING_SECRET=use-a-different-secret-than-client-secret
+STRAVA_REDIRECT_URI=http://localhost:8080/strava/callback
+STRAVA_CLUB_ID=1766412
+STRAVA_SIGNUP_STORE_PATH=data/strava-signups.json
+STRAVA_AUTH_COOKIE_NAME=runtime_strava_auth
+# Set to true in production so cookies are only sent over HTTPS.
+STRAVA_AUTH_COOKIE_SECURE=false

--- a/README.md
+++ b/README.md
@@ -1,7 +1,158 @@
 # Runtime backend
 
-Backend for the Runtime website.
+Ktor backend for the Runtime website's Strava integration.
 
-Spring Framework + Kotlin.
+## What it does
 
-[Spring Docs](https://spring.io/projects/spring-framework)
+- handles Strava OAuth signup for members
+- stores signed-up athletes and refresh tokens in a local JSON store
+- exposes per-user stats endpoints for the existing `STRAVA` page
+- exposes leaderboard endpoints for `run`, `ride`, and `swim` with `ytd`, `30d`, and `7d` periods
+- keeps the old club helper endpoints available under both `/strava/*` and `/api/strava/*`
+
+## Requirements
+
+- Java 21+
+- Gradle 9+
+- a Strava app with OAuth callback configured
+
+## Environment variables
+
+Copy the template and fill in the real values:
+
+```bash
+cp .env.example .env.local
+```
+
+Required:
+
+- `FRONTEND_BASE_URL` - frontend origin used for OAuth redirects, for example `http://localhost:5173`
+- `CORS_ALLOWED_ORIGINS` - comma-separated list of allowed browser origins
+- `STRAVA_CLIENT_ID` - Strava app client id
+- `STRAVA_CLIENT_SECRET` - Strava app client secret
+- `STRAVA_COOKIE_SIGNING_SECRET` - dedicated secret used only for signing auth cookies
+- `STRAVA_REDIRECT_URI` - backend callback URL registered in Strava, for example `http://localhost:8080/strava/callback`
+
+Optional:
+
+- `STRAVA_CLUB_ID` - enables `/strava/info`, `/strava/members`, `/strava/admins`
+- `STRAVA_SIGNUP_STORE_PATH` - path to the JSON signup store, defaults to `data/strava-signups.json`
+- `STRAVA_AUTH_COOKIE_NAME` - auth cookie name, defaults to `runtime_strava_auth`
+- `STRAVA_AUTH_COOKIE_SECURE` - set `false` for local `http`, `true` for deployed `https`
+
+## Run locally
+
+```bash
+gradle run
+```
+
+The server listens on `http://localhost:8080` by default.
+
+## OAuth flow
+
+1. Frontend sends the user to `GET /strava/authorize?page=leaderboard` or `GET /strava/authorize?page=strava`
+2. Backend redirects to Strava OAuth
+3. Strava calls `GET /strava/callback`
+4. Backend exchanges the code for tokens, stores the athlete, sets a signed auth cookie, and redirects back to the frontend with `?page=...&strava=success`
+
+The signup store is file-backed on purpose so the feature works without adding a database to this repo. The path is configurable through `STRAVA_SIGNUP_STORE_PATH`.
+
+## API
+
+All routes exist under both `/strava` and `/api/strava`.
+
+### Auth
+
+- `GET /strava/authorize?page=leaderboard|strava`
+- `GET /strava/callback`
+
+### Stats for the signed-in athlete
+
+- `GET /strava/stats/ytd`
+- `GET /strava/stats/activities`
+- `GET /strava/stats/monthly`
+
+These endpoints require the signed auth cookie set during OAuth callback.
+
+### Leaderboard
+
+- `GET /strava/stats/leaderboard?activity=run&period=ytd`
+- `GET /strava/stats/leaderboard?activity=ride&period=30d`
+- `GET /strava/stats/leaderboard?activity=swim&period=7d`
+
+Supported values:
+
+- `activity`: `run`, `ride`, `swim`
+- `period`: `ytd`, `30d`, `7d`
+
+Response shape:
+
+```json
+{
+  "type": "leaderboard",
+  "data": {
+    "activity": "run",
+    "period": "ytd",
+    "total_athletes": 3,
+    "entries": [
+      {
+        "rank": 1,
+        "athlete_id": 123,
+        "athlete_name": "Ada Lovelace",
+        "avatar_url": "https://...",
+        "city": "Oslo",
+        "state": null,
+        "country": "Norway",
+        "metrics": {
+          "primary_label": "distance_km",
+          "primary_value": 314.159,
+          "secondary_label": "pace_per_km_seconds",
+          "secondary_value": 313.0,
+          "tertiary_label": "elevation_m",
+          "tertiary_value": 2100.0
+        },
+        "totals": {
+          "count": 42,
+          "distance": 314159.0,
+          "moving_time": 98340,
+          "elapsed_time": 100100,
+          "elevation_gain": 2100.0,
+          "achievement_count": 0
+        }
+      }
+    ]
+  },
+  "fetched_at": "2026-03-23T12:00:00Z"
+}
+```
+
+### Club helper routes
+
+- `GET /strava/info`
+- `GET /strava/members`
+- `GET /strava/admins`
+
+These require `STRAVA_CLUB_ID` and at least one signed-up athlete so the backend has a valid Strava token to use.
+
+## Development notes
+
+- tokens are refreshed automatically when they are close to expiry
+- leaderboard ranking sorts by total distance, then moving time, then athlete name
+- leaderboard periods are calculated from raw Strava activities: year-to-date, last 30 days, or last 7 days
+- activity matching includes common Strava variants like `TrailRun`, `VirtualRide`, and `VirtualRun`
+- cookie auth is signed with `STRAVA_COOKIE_SIGNING_SECRET`
+- frontend calls must use `credentials: include`
+
+## Security
+
+- the signup store contains refresh tokens; keep the file outside source control, lock down file permissions, and use restrictive access controls
+- for deployed environments, encrypt token storage at rest and keep the encryption key in a real secret manager
+- set `STRAVA_AUTH_COOKIE_SECURE=true` in production so cookies are only sent over HTTPS
+- keep `STRAVA_CLIENT_SECRET` and `STRAVA_COOKIE_SIGNING_SECRET` separate so a leak in one path does not compromise the other
+- define retention/deletion routines for athlete data and refresh tokens before using this in production
+
+## Verify
+
+```bash
+gradle build
+```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,10 @@ plugins {
     kotlin("plugin.serialization") version "1.9.10"
 }
 
+kotlin {
+    jvmToolchain(21)
+}
+
 group = "io.github.runtimeifi"
 version = "1.0-SNAPSHOT"
 
@@ -18,11 +22,19 @@ repositories {
 dependencies {
     implementation("io.ktor:ktor-server-core:2.3.5")
     implementation("io.ktor:ktor-server-netty:2.3.5")
+    implementation("io.ktor:ktor-server-cors:2.3.5")
+    implementation("io.ktor:ktor-server-call-logging:2.3.5")
+    implementation("io.ktor:ktor-server-status-pages:2.3.5")
+    implementation("io.ktor:ktor-server-content-negotiation:2.3.5")
     
     implementation("io.ktor:ktor-client-core:2.3.5")
     implementation("io.ktor:ktor-client-cio:2.3.5")
+    implementation("io.ktor:ktor-client-content-negotiation:2.3.5")
+    implementation("io.ktor:ktor-client-logging:2.3.5")
+    implementation("io.ktor:ktor-client-auth:2.3.5")
     
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
+    implementation("io.ktor:ktor-serialization-kotlinx-json:2.3.5")
     
     implementation("ch.qos.logback:logback-classic:1.4.11")
     

--- a/src/main/kotlin/io/github/runtimeifi/Application.kt
+++ b/src/main/kotlin/io/github/runtimeifi/Application.kt
@@ -1,14 +1,91 @@
 package io.github.runtimeifi
 
+import io.github.runtimeifi.config.loadAppConfig
+import io.github.runtimeifi.routes.respondError
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationStopped
+import io.ktor.server.application.install
+import io.ktor.server.plugins.callloging.CallLogging
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.plugins.cors.routing.CORS
+import io.ktor.server.plugins.statuspages.StatusPages
 import io.ktor.server.routing.*
 import io.github.runtimeifi.routes.stravaRoutes
+import io.github.runtimeifi.services.StravaService
+import io.github.runtimeifi.services.StravaSignupStore
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import kotlinx.serialization.json.Json
+import org.slf4j.event.Level
 
 fun main() {
     embeddedServer(Netty, port = 8080) {
+        val config = loadAppConfig()
+        val json = Json {
+            ignoreUnknownKeys = true
+            prettyPrint = false
+        }
+        val httpClient = HttpClient(CIO) {
+            install(HttpTimeout) {
+                requestTimeoutMillis = 15000
+                connectTimeoutMillis = 10000
+                socketTimeoutMillis = 15000
+            }
+            install(ClientContentNegotiation) {
+                json(json)
+            }
+        }
+        environment.monitor.subscribe(ApplicationStopped) {
+            httpClient.close()
+        }
+        val signupStore = StravaSignupStore(config.signupStorePath, json)
+        val stravaService = StravaService(config, httpClient, signupStore, json)
+
+        configureHttp(config, json)
         routing {
-            stravaRoutes()
+            stravaRoutes(stravaService, config)
         }
     }.start(wait = true)
+}
+
+private fun Application.configureHttp(config: io.github.runtimeifi.config.AppConfig, json: Json) {
+    install(CallLogging) {
+        level = Level.INFO
+    }
+
+    install(ContentNegotiation) {
+        json(json)
+    }
+
+    install(CORS) {
+        allowMethod(HttpMethod.Get)
+        allowMethod(HttpMethod.Post)
+        allowHeader(HttpHeaders.ContentType)
+        allowHeader(HttpHeaders.Authorization)
+        allowCredentials = true
+        config.allowedOrigins.forEach { origin ->
+            try {
+                val parsed = java.net.URI(origin)
+                val host = if (parsed.port == -1) parsed.host else "${parsed.host}:${parsed.port}"
+                allowHost(host, schemes = listOf(parsed.scheme))
+            } catch (exception: Exception) {
+                throw IllegalStateException("Invalid CORS_ALLOWED_ORIGINS entry: $origin", exception)
+            }
+        }
+    }
+
+    install(StatusPages) {
+        exception<Throwable> { call, cause ->
+            this@configureHttp.environment.log.error("Unhandled request failure", cause)
+            call.respondError(HttpStatusCode.InternalServerError, cause.message ?: "Unexpected server error")
+        }
+    }
 }

--- a/src/main/kotlin/io/github/runtimeifi/config/AppConfig.kt
+++ b/src/main/kotlin/io/github/runtimeifi/config/AppConfig.kt
@@ -1,0 +1,101 @@
+package io.github.runtimeifi.config
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.Path
+import kotlin.io.path.exists
+
+data class AppConfig(
+    val frontendBaseUrl: String,
+    val allowedOrigins: List<String>,
+    val stravaClientId: String,
+    val stravaClientSecret: String,
+    val cookieSigningSecret: String,
+    val stravaRedirectUri: String,
+    val stravaClubId: Long?,
+    val signupStorePath: Path,
+    val cookieName: String,
+    val cookieSecure: Boolean,
+) {
+    override fun toString(): String {
+        return "AppConfig(frontendBaseUrl=$frontendBaseUrl, allowedOrigins=$allowedOrigins, stravaClientId=***, cookieSigningSecret=***, stravaRedirectUri=$stravaRedirectUri, stravaClubId=$stravaClubId, signupStorePath=$signupStorePath, cookieName=$cookieName, cookieSecure=$cookieSecure)"
+    }
+}
+
+fun loadAppConfig(): AppConfig {
+    val frontendBaseUrl = env("FRONTEND_BASE_URL", "http://localhost:5173").trimEnd('/')
+    val configuredAllowedOrigins = env("CORS_ALLOWED_ORIGINS", frontendBaseUrl)
+        .split(',')
+        .map { it.trim() }
+        .filter { it.isNotEmpty() }
+    val allowedOrigins = if (configuredAllowedOrigins.isEmpty()) {
+        System.err.println("CORS_ALLOWED_ORIGINS was empty after parsing, falling back to FRONTEND_BASE_URL=$frontendBaseUrl")
+        listOf(frontendBaseUrl)
+    } else {
+        configuredAllowedOrigins
+    }
+
+    return AppConfig(
+        frontendBaseUrl = frontendBaseUrl,
+        allowedOrigins = allowedOrigins,
+        stravaClientId = env("STRAVA_CLIENT_ID"),
+        stravaClientSecret = env("STRAVA_CLIENT_SECRET"),
+        cookieSigningSecret = env("STRAVA_COOKIE_SIGNING_SECRET", System.getenv("STRAVA_CLIENT_SECRET")),
+        stravaRedirectUri = env("STRAVA_REDIRECT_URI"),
+        stravaClubId = envOrNull("STRAVA_CLUB_ID")?.toLongOrNull(),
+        signupStorePath = Path(env("STRAVA_SIGNUP_STORE_PATH", "data/strava-signups.json")),
+        cookieName = env("STRAVA_AUTH_COOKIE_NAME", "runtime_strava_auth"),
+        cookieSecure = env("STRAVA_AUTH_COOKIE_SECURE", "true").toBooleanStrictOrNull() ?: true,
+    )
+}
+
+private fun env(name: String, defaultValue: String? = null): String {
+    val value = System.getenv(name)?.trim().orEmpty()
+    if (value.isNotEmpty()) {
+        return value
+    }
+
+    val localValue = readLocalEnv()[name]?.trim().orEmpty()
+    if (localValue.isNotEmpty()) {
+        return localValue
+    }
+
+    if (defaultValue != null) {
+        return defaultValue
+    }
+
+    error("Missing required environment variable: $name. Set it in your shell or in runtime-backend/.env.local")
+}
+
+private fun envOrNull(name: String): String? {
+    val value = System.getenv(name)?.trim().orEmpty()
+    if (value.isNotEmpty()) {
+        return value
+    }
+
+    val localValue = readLocalEnv()[name]?.trim().orEmpty()
+    return localValue.ifEmpty { null }
+}
+
+private val localEnvCache: Map<String, String> by lazy {
+    val envPath = Path(".env.local")
+    if (!envPath.exists()) {
+        emptyMap()
+    } else {
+        Files.readAllLines(envPath)
+            .mapNotNull { line ->
+                val trimmed = line.trim()
+                if (trimmed.isEmpty() || trimmed.startsWith('#') || !trimmed.contains('=')) {
+                    null
+                } else {
+                    val separatorIndex = trimmed.indexOf('=')
+                    val key = trimmed.substring(0, separatorIndex).trim()
+                    val rawValue = trimmed.substring(separatorIndex + 1).trim()
+                    key to rawValue.removeSurrounding("\"").removeSurrounding("'")
+                }
+            }
+            .toMap()
+    }
+}
+
+private fun readLocalEnv(): Map<String, String> = localEnvCache

--- a/src/main/kotlin/io/github/runtimeifi/models/StravaModels.kt
+++ b/src/main/kotlin/io/github/runtimeifi/models/StravaModels.kt
@@ -1,0 +1,174 @@
+package io.github.runtimeifi.models
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ApiEnvelope<T>(
+    val type: String,
+    val data: T,
+    val fetched_at: String,
+)
+
+@Serializable
+data class StravaErrorResponse(
+    val error: String,
+    val detail: String,
+)
+
+@Serializable
+data class StravaTokenResponse(
+    val token_type: String,
+    val access_token: String,
+    val refresh_token: String,
+    val expires_at: Long,
+    val athlete: StravaAthlete? = null,
+)
+
+@Serializable
+data class StravaAthlete(
+    val id: Long,
+    val firstname: String = "",
+    val lastname: String = "",
+    val username: String? = null,
+    @SerialName("profile") val profileUrl: String? = null,
+    @SerialName("profile_medium") val profileMediumUrl: String? = null,
+    val city: String? = null,
+    val state: String? = null,
+    val country: String? = null,
+)
+
+@Serializable
+data class StravaAthleteStats(
+    val biggest_ride_distance: Double = 0.0,
+    val biggest_climb_elevation_gain: Double = 0.0,
+    val recent_run_totals: ActivityTotals,
+    val all_run_totals: ActivityTotals,
+    val recent_ride_totals: ActivityTotals,
+    val all_ride_totals: ActivityTotals,
+    val ytd_run_totals: ActivityTotals,
+    val ytd_ride_totals: ActivityTotals,
+)
+
+@Serializable
+data class ActivityTotals(
+    val count: Int,
+    val distance: Double,
+    val moving_time: Int,
+    val elapsed_time: Int,
+    val elevation_gain: Double,
+    val achievement_count: Int = 0,
+)
+
+@Serializable
+data class StravaActivity(
+    val id: Long,
+    val name: String,
+    val type: String,
+    val distance: Double,
+    val moving_time: Int,
+    val elapsed_time: Int,
+    val total_elevation_gain: Double = 0.0,
+    val average_speed: Double? = null,
+    val max_speed: Double? = null,
+    val average_heartrate: Double? = null,
+    val max_heartrate: Double? = null,
+    val achievement_count: Int? = null,
+    val kudos_count: Int? = null,
+    val start_date: String,
+)
+
+@Serializable
+data class SignedUpAthlete(
+    val athleteId: Long,
+    val firstName: String,
+    val lastName: String,
+    val profileUrl: String? = null,
+    val profileMediumUrl: String? = null,
+    val city: String? = null,
+    val state: String? = null,
+    val country: String? = null,
+    val refreshToken: String,
+    val accessToken: String,
+    val expiresAt: Long,
+    val signedUpAt: String,
+    val lastSyncedAt: String? = null,
+) {
+    override fun toString(): String {
+        return "SignedUpAthlete(athleteId=$athleteId, firstName=$firstName, lastName=$lastName, refreshToken=***, accessToken=***, expiresAt=$expiresAt, signedUpAt=$signedUpAt, lastSyncedAt=$lastSyncedAt)"
+    }
+}
+
+@Serializable
+data class RecentActivitiesResponse(
+    val activities: List<StravaActivity>,
+    val count: Int,
+)
+
+@Serializable
+data class MonthlySummary(
+    val months: List<MonthlyAggregate>,
+    val summary: MonthlySummaryTotals,
+)
+
+@Serializable
+data class MonthlyAggregate(
+    val month: String,
+    val run_count: Int,
+    val run_distance: Double,
+    val run_moving_time: Int,
+    val run_elevation_gain: Double,
+    val ride_count: Int,
+    val ride_distance: Double,
+    val ride_moving_time: Int,
+    val ride_elevation_gain: Double,
+    val total_count: Int,
+    val total_distance: Double,
+    val total_moving_time: Int,
+    val total_elevation_gain: Double,
+)
+
+@Serializable
+data class MonthlySummaryTotals(
+    val total_activities: Int,
+    val total_distance: Double,
+    val total_moving_time: Int,
+    val total_elevation_gain: Double,
+)
+
+@Serializable
+data class LeaderboardResponse(
+    val activity: String,
+    val period: String,
+    val total_athletes: Int,
+    val entries: List<LeaderboardEntry>,
+)
+
+@Serializable
+data class LeaderboardEntry(
+    val rank: Int,
+    val athlete_id: Long,
+    val athlete_name: String,
+    val avatar_url: String? = null,
+    val city: String? = null,
+    val state: String? = null,
+    val country: String? = null,
+    val metrics: LeaderboardMetrics,
+    val totals: ActivityTotals,
+)
+
+@Serializable
+data class LeaderboardMetrics(
+    val primary_label: String,
+    val primary_value: Double,
+    val secondary_label: String,
+    val secondary_value: Double,
+    val tertiary_label: String,
+    val tertiary_value: Double? = null,
+)
+
+@Serializable
+data class OAuthStatePayload(
+    val page: String,
+    val issuedAtEpochSeconds: Long,
+)

--- a/src/main/kotlin/io/github/runtimeifi/routes/RouteHelpers.kt
+++ b/src/main/kotlin/io/github/runtimeifi/routes/RouteHelpers.kt
@@ -1,0 +1,14 @@
+package io.github.runtimeifi.routes
+
+import io.github.runtimeifi.models.StravaErrorResponse
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.response.respond
+
+suspend fun ApplicationCall.respondError(
+    status: HttpStatusCode,
+    detail: String,
+    error: String = status.description,
+) {
+    respond(status, StravaErrorResponse(error = error, detail = detail))
+}

--- a/src/main/kotlin/io/github/runtimeifi/routes/StravaRoutes.kt
+++ b/src/main/kotlin/io/github/runtimeifi/routes/StravaRoutes.kt
@@ -1,52 +1,225 @@
 package io.github.runtimeifi.routes
 
-import io.ktor.server.application.*
-import io.ktor.server.response.*
-import io.ktor.server.routing.*
-import io.ktor.client.*
-import io.ktor.client.request.*
-import io.ktor.client.statement.*
-import io.ktor.http.*
+import io.github.runtimeifi.config.AppConfig
+import io.github.runtimeifi.models.ApiEnvelope
+import io.github.runtimeifi.models.LeaderboardResponse
+import io.github.runtimeifi.services.StravaService
+import io.ktor.http.Cookie
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.encodeURLQueryComponent
+import io.ktor.server.application.call
+import io.ktor.server.response.respond
+import io.ktor.server.response.respondRedirect
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.route
+import java.time.Instant
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
 
-// Strava Club endpoints: info, leaderboard, members, admins
-// read more about the endpoints here: https://developers.strava.com/docs/reference/#api-Clubs 
-fun Route.stravaRoutes() {
-    val client = HttpClient()
-    val clubId = 1766412 // hardcoded Strava club ID
-    val accessToken = System.getenv("STRAVA_ACCESS_TOKEN")
+fun Route.stravaRoutes(
+    service: StravaService,
+    config: AppConfig,
+) {
+    registerStravaRoutes("/strava", service, config)
+    registerStravaRoutes("/api/strava", service, config)
+}
 
-    route("/api/strava") {
+private fun Route.registerStravaRoutes(
+    basePath: String,
+    service: StravaService,
+    config: AppConfig,
+) {
+    route(basePath) {
+        get("/authorize") {
+            val page = call.request.queryParameters["page"] ?: "leaderboard"
+            call.respondRedirect(service.buildAuthorizationUrl(page))
+        }
 
-        // Returns club info 
+        get("/callback") {
+            val error = call.request.queryParameters["error"]
+            if (!error.isNullOrBlank()) {
+                call.respondRedirect(frontendRedirect(config.frontendBaseUrl, "leaderboard", false, error))
+                return@get
+            }
+
+            val code = call.request.queryParameters["code"]
+            if (code.isNullOrBlank()) {
+                call.respondRedirect(frontendRedirect(config.frontendBaseUrl, "leaderboard", false, "Missing authorization code"))
+                return@get
+            }
+
+            runCatching {
+                service.completeSignup(code, call.request.queryParameters["state"])
+            }.onSuccess { (athlete, page) ->
+                call.response.cookies.append(
+                    Cookie(
+                        name = config.cookieName,
+                        value = signCookieValue(athlete.athleteId, config.cookieSigningSecret),
+                        path = "/",
+                        httpOnly = true,
+                        secure = config.cookieSecure,
+                        extensions = mapOf("SameSite" to if (config.cookieSecure) "None" else "Lax"),
+                    )
+                )
+                call.respondRedirect(frontendRedirect(config.frontendBaseUrl, page, true, null))
+            }.onFailure { throwable ->
+                call.application.environment.log.error("Strava signup failed", throwable)
+                call.respondRedirect(frontendRedirect(config.frontendBaseUrl, "leaderboard", false, "Failed to connect Strava"))
+            }
+        }
+
+        route("/stats") {
+            get("/ytd") {
+                val athleteId = currentAthleteId(call.request.cookies[config.cookieName], config.cookieSigningSecret)
+                if (athleteId == null) {
+                    call.respondError(HttpStatusCode.Unauthorized, "Connect Strava first to view your stats.")
+                    return@get
+                }
+
+                runCatching {
+                    service.getYearToDateStats(athleteId)
+                }.onSuccess { stats ->
+                    call.respond(
+                        ApiEnvelope(
+                            type = "ytd",
+                            data = mapOf(
+                                "run_totals" to stats.ytd_run_totals,
+                                "ride_totals" to stats.ytd_ride_totals,
+                            ),
+                            fetched_at = Instant.now().toString(),
+                        )
+                    )
+                }.onFailure { throwable ->
+                    call.respondError(HttpStatusCode.BadGateway, throwable.message ?: "Failed to load YTD stats")
+                }
+            }
+
+            get("/activities") {
+                val athleteId = currentAthleteId(call.request.cookies[config.cookieName], config.cookieSigningSecret)
+                if (athleteId == null) {
+                    call.respondError(HttpStatusCode.Unauthorized, "Connect Strava first to view your activities.")
+                    return@get
+                }
+
+                runCatching {
+                    service.getRecentActivities(athleteId)
+                }.onSuccess { activities ->
+                    call.respond(ApiEnvelope(type = "recent_activities", data = activities, fetched_at = Instant.now().toString()))
+                }.onFailure { throwable ->
+                    call.respondError(HttpStatusCode.BadGateway, throwable.message ?: "Failed to load activities")
+                }
+            }
+
+            get("/monthly") {
+                val athleteId = currentAthleteId(call.request.cookies[config.cookieName], config.cookieSigningSecret)
+                if (athleteId == null) {
+                    call.respondError(HttpStatusCode.Unauthorized, "Connect Strava first to view your monthly stats.")
+                    return@get
+                }
+
+                runCatching {
+                    service.getMonthlySummary(athleteId)
+                }.onSuccess { summary ->
+                    call.respond(ApiEnvelope(type = "monthly", data = summary, fetched_at = Instant.now().toString()))
+                }.onFailure { throwable ->
+                    call.respondError(HttpStatusCode.BadGateway, throwable.message ?: "Failed to load monthly stats")
+                }
+            }
+
+            get("/leaderboard") {
+                val activity = call.request.queryParameters["activity"] ?: "run"
+                val period = call.request.queryParameters["period"] ?: "ytd"
+                val normalizedActivity = when (activity.lowercase()) {
+                    "ride", "cycling", "bike" -> "ride"
+                    "swim", "swimming" -> "swim"
+                    else -> "run"
+                }
+                val normalizedPeriod = when (period.lowercase()) {
+                    "7d", "7days", "week" -> "7d"
+                    "30d", "30days", "month" -> "30d"
+                    else -> "ytd"
+                }
+                runCatching {
+                    service.getLeaderboard(normalizedActivity, normalizedPeriod)
+                }.onSuccess { entries ->
+                    call.respond(
+                        ApiEnvelope(
+                            type = "leaderboard",
+                            data = LeaderboardResponse(
+                                activity = normalizedActivity,
+                                period = normalizedPeriod,
+                                total_athletes = entries.size,
+                                entries = entries,
+                            ),
+                            fetched_at = Instant.now().toString(),
+                        )
+                    )
+                }.onFailure { throwable ->
+                    call.respondError(HttpStatusCode.BadGateway, throwable.message ?: "Failed to load leaderboard")
+                }
+            }
+        }
+
         get("/info") {
-            val response: String = client.get("https://www.strava.com/api/v3/clubs/$clubId") {
-                headers { append("Authorization", "Bearer $accessToken") }
-            }.bodyAsText()
-            call.respondText(response, ContentType.Application.Json) 
-        }
-
-        // Returns recent activities (leaderboard, 30 by default)
-        get("/leaderboard") {
-            val response: String = client.get("https://www.strava.com/api/v3/clubs/$clubId/activities") {
-                headers { append("Authorization", "Bearer $accessToken") }
-            }.bodyAsText()
+            val response = service.getClubInfo()
+            if (response == null) {
+                call.respondError(HttpStatusCode.ServiceUnavailable, "Club info unavailable. Configure STRAVA_CLUB_ID and at least one signup.")
+                return@get
+            }
             call.respondText(response, ContentType.Application.Json)
         }
 
-        // Returns list of members (30 by default)
         get("/members") {
-            val response: String = client.get("https://www.strava.com/api/v3/clubs/$clubId/members") {
-                headers { append("Authorization", "Bearer $accessToken") }
-            }.bodyAsText()
+            val response = service.getClubMembers()
+            if (response == null) {
+                call.respondError(HttpStatusCode.ServiceUnavailable, "Members unavailable. Configure STRAVA_CLUB_ID and at least one signup.")
+                return@get
+            }
             call.respondText(response, ContentType.Application.Json)
         }
 
-        // Returns list of admins
         get("/admins") {
-            val response: String = client.get("https://www.strava.com/api/v3/clubs/$clubId/admins") {
-                headers { append("Authorization", "Bearer $accessToken") }
-            }.bodyAsText()
+            val response = service.getClubAdmins()
+            if (response == null) {
+                call.respondError(HttpStatusCode.ServiceUnavailable, "Admins unavailable. Configure STRAVA_CLUB_ID and at least one signup.")
+                return@get
+            }
             call.respondText(response, ContentType.Application.Json)
         }
     }
+}
+
+private fun frontendRedirect(frontendBaseUrl: String, page: String, success: Boolean, message: String?): String {
+    val state = if (success) "success" else "error"
+    val query = buildList {
+        add("page=${page.encodeURLQueryComponent()}")
+        add("strava=$state")
+        if (!message.isNullOrBlank()) {
+            add("message=${message.encodeURLQueryComponent()}")
+        }
+    }.joinToString("&")
+    return "$frontendBaseUrl/?$query"
+}
+
+private fun currentAthleteId(cookieValue: String?, secret: String): Long? {
+    val raw = cookieValue ?: return null
+    val parts = raw.split('.')
+    if (parts.size != 2) {
+        return null
+    }
+
+    val athleteId = parts[0].toLongOrNull() ?: return null
+    val signature = parts[1]
+    return if (signature == signCookieValue(athleteId, secret).substringAfter('.')) athleteId else null
+}
+
+private fun signCookieValue(athleteId: Long, secret: String): String {
+    val mac = Mac.getInstance("HmacSHA256")
+    mac.init(SecretKeySpec(secret.toByteArray(), "HmacSHA256"))
+    val signature = mac.doFinal(athleteId.toString().toByteArray())
+        .joinToString(separator = "") { byte -> "%02x".format(byte) }
+    return "$athleteId.$signature"
 }

--- a/src/main/kotlin/io/github/runtimeifi/services/StravaService.kt
+++ b/src/main/kotlin/io/github/runtimeifi/services/StravaService.kt
@@ -1,0 +1,460 @@
+package io.github.runtimeifi.services
+
+import io.github.runtimeifi.config.AppConfig
+import io.github.runtimeifi.models.ActivityTotals
+import io.github.runtimeifi.models.LeaderboardEntry
+import io.github.runtimeifi.models.LeaderboardMetrics
+import io.github.runtimeifi.models.MonthlyAggregate
+import io.github.runtimeifi.models.MonthlySummary
+import io.github.runtimeifi.models.MonthlySummaryTotals
+import io.github.runtimeifi.models.OAuthStatePayload
+import io.github.runtimeifi.models.RecentActivitiesResponse
+import io.github.runtimeifi.models.SignedUpAthlete
+import io.github.runtimeifi.models.StravaActivity
+import io.github.runtimeifi.models.StravaAthlete
+import io.github.runtimeifi.models.StravaAthleteStats
+import io.github.runtimeifi.models.StravaTokenResponse
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+import kotlin.math.max
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.forms.FormDataContent
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.parameter
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.Parameters
+
+class StravaService(
+    private val config: AppConfig,
+    private val client: HttpClient,
+    private val store: StravaSignupStore,
+    private val json: Json,
+) {
+    fun buildAuthorizationUrl(page: String): String {
+        val safePage = normalizePage(page)
+        val state = signState(OAuthStatePayload(safePage, Instant.now().epochSecond))
+        val query = listOf(
+            "client_id=${urlEncode(config.stravaClientId)}",
+            "response_type=code",
+            "redirect_uri=${urlEncode(config.stravaRedirectUri)}",
+            "approval_prompt=force",
+            "scope=${urlEncode("read,activity:read_all")}",
+            "state=${urlEncode(state)}",
+        ).joinToString("&")
+
+        return "https://www.strava.com/oauth/authorize?$query"
+    }
+
+    suspend fun completeSignup(code: String, state: String?): Pair<SignedUpAthlete, String> {
+        val tokenResponse = exchangeCodeForToken(code)
+        val athlete = tokenResponse.athlete ?: error("Strava did not return athlete details during signup")
+        val now = Instant.now().toString()
+        val signup = SignedUpAthlete(
+            athleteId = athlete.id,
+            firstName = athlete.firstname,
+            lastName = athlete.lastname,
+            profileUrl = athlete.profileUrl,
+            profileMediumUrl = athlete.profileMediumUrl,
+            city = athlete.city,
+            state = athlete.state,
+            country = athlete.country,
+            refreshToken = tokenResponse.refresh_token,
+            accessToken = tokenResponse.access_token,
+            expiresAt = tokenResponse.expires_at,
+            signedUpAt = now,
+            lastSyncedAt = now,
+        )
+        store.upsert(signup)
+
+        val returnPage = verifyState(state).page
+        return signup to returnPage
+    }
+
+    suspend fun getYearToDateStats(athleteId: Long): StravaAthleteStats {
+        val athlete = getSignedUpAthlete(athleteId)
+        val token = getValidAccessToken(athlete)
+        return client.get("https://www.strava.com/api/v3/athletes/$athleteId/stats") {
+            header("Authorization", "Bearer $token")
+        }.body()
+    }
+
+    suspend fun getRecentActivities(athleteId: Long): RecentActivitiesResponse {
+        val athlete = getSignedUpAthlete(athleteId)
+        val token = getValidAccessToken(athlete)
+        val activities = client.get("https://www.strava.com/api/v3/athlete/activities") {
+            header("Authorization", "Bearer $token")
+            parameter("per_page", 30)
+            parameter("page", 1)
+        }.body<List<StravaActivity>>()
+
+        return RecentActivitiesResponse(
+            activities = activities,
+            count = activities.size,
+        )
+    }
+
+    suspend fun getMonthlySummary(athleteId: Long): MonthlySummary {
+        val athlete = getSignedUpAthlete(athleteId)
+        val token = getValidAccessToken(athlete)
+        val activities = fetchActivitiesSince(token, LocalDate.now(ZoneOffset.UTC).minusMonths(11).withDayOfMonth(1))
+        return aggregateMonthly(activities)
+    }
+
+    suspend fun getLeaderboard(activity: String, period: String): List<LeaderboardEntry> = coroutineScope {
+        val normalizedActivity = normalizeActivity(activity)
+        val normalizedPeriod = normalizePeriod(period)
+        val startDate = leaderboardStartDate(normalizedPeriod)
+        val signups = store.getAll()
+        val entries = signups.map { signup ->
+            async {
+                runCatching {
+                    val token = getValidAccessToken(signup)
+                    val activities = fetchActivitiesSince(token, startDate)
+                    val totals = aggregateLeaderboardTotals(activities, normalizedActivity)
+
+                    signup to totals
+                }.getOrNull()
+            }
+        }.mapNotNull { it.await() }
+
+        entries
+            .filter { (_, totals) -> totals.distance > 0.0 || totals.count > 0 }
+            .sortedWith(
+                compareByDescending<Pair<SignedUpAthlete, ActivityTotals>> { it.second.distance }
+                    .thenByDescending { it.second.moving_time }
+                    .thenBy { athleteDisplayName(it.first) }
+            )
+            .mapIndexed { index, (signup, totals) ->
+                LeaderboardEntry(
+                    rank = index + 1,
+                    athlete_id = signup.athleteId,
+                    athlete_name = athleteDisplayName(signup),
+                    avatar_url = signup.profileMediumUrl ?: signup.profileUrl,
+                    city = signup.city,
+                    state = signup.state,
+                    country = signup.country,
+                    metrics = leaderboardMetrics(normalizedActivity, totals),
+                    totals = totals,
+                )
+            }
+    }
+
+    suspend fun getClubInfo(): String? {
+        val clubId = config.stravaClubId ?: return null
+        val token = getAnyClubToken() ?: return null
+        return client.get("https://www.strava.com/api/v3/clubs/$clubId") {
+            header("Authorization", "Bearer $token")
+        }.body()
+    }
+
+    suspend fun getClubMembers(): String? {
+        val clubId = config.stravaClubId ?: return null
+        val token = getAnyClubToken() ?: return null
+        return client.get("https://www.strava.com/api/v3/clubs/$clubId/members") {
+            header("Authorization", "Bearer $token")
+        }.body()
+    }
+
+    suspend fun getClubAdmins(): String? {
+        val clubId = config.stravaClubId ?: return null
+        val token = getAnyClubToken() ?: return null
+        return client.get("https://www.strava.com/api/v3/clubs/$clubId/admins") {
+            header("Authorization", "Bearer $token")
+        }.body()
+    }
+
+    private suspend fun getSignedUpAthlete(athleteId: Long): SignedUpAthlete {
+        return store.getAll().firstOrNull { it.athleteId == athleteId }
+            ?: error("No Strava signup found for athlete $athleteId")
+    }
+
+    private suspend fun getAnyClubToken(): String? {
+        val signup = store.getAll().firstOrNull() ?: return null
+        return getValidAccessToken(signup)
+    }
+
+    private suspend fun getValidAccessToken(athlete: SignedUpAthlete): String {
+        val now = Instant.now().epochSecond
+        if (athlete.expiresAt > now + 120) {
+            return athlete.accessToken
+        }
+
+        val refreshed = refreshAccessToken(athlete.refreshToken)
+        val updated = athlete.copy(
+            accessToken = refreshed.access_token,
+            refreshToken = refreshed.refresh_token,
+            expiresAt = refreshed.expires_at,
+            firstName = refreshed.athlete?.firstname?.ifBlank { athlete.firstName } ?: athlete.firstName,
+            lastName = refreshed.athlete?.lastname?.ifBlank { athlete.lastName } ?: athlete.lastName,
+            profileUrl = refreshed.athlete?.profileUrl ?: athlete.profileUrl,
+            profileMediumUrl = refreshed.athlete?.profileMediumUrl ?: athlete.profileMediumUrl,
+            city = refreshed.athlete?.city ?: athlete.city,
+            state = refreshed.athlete?.state ?: athlete.state,
+            country = refreshed.athlete?.country ?: athlete.country,
+            lastSyncedAt = Instant.now().toString(),
+        )
+        store.upsert(updated)
+        return updated.accessToken
+    }
+
+    private suspend fun exchangeCodeForToken(code: String): StravaTokenResponse {
+        return client.post("https://www.strava.com/api/v3/oauth/token") {
+            setBody(
+                FormDataContent(
+                    Parameters.build {
+                        append("client_id", config.stravaClientId)
+                        append("client_secret", config.stravaClientSecret)
+                        append("code", code)
+                        append("grant_type", "authorization_code")
+                    }
+                )
+            )
+        }.body()
+    }
+
+    private suspend fun refreshAccessToken(refreshToken: String): StravaTokenResponse {
+        return client.post("https://www.strava.com/api/v3/oauth/token") {
+            setBody(
+                FormDataContent(
+                    Parameters.build {
+                        append("client_id", config.stravaClientId)
+                        append("client_secret", config.stravaClientSecret)
+                        append("refresh_token", refreshToken)
+                        append("grant_type", "refresh_token")
+                    }
+                )
+            )
+        }.body()
+    }
+
+    private suspend fun fetchActivitiesSince(accessToken: String, startDate: LocalDate): List<StravaActivity> {
+        val afterEpoch = startDate.atStartOfDay().toEpochSecond(ZoneOffset.UTC)
+        val activities = mutableListOf<StravaActivity>()
+        var page = 1
+
+        while (true) {
+            val batch = client.get("https://www.strava.com/api/v3/athlete/activities") {
+                header("Authorization", "Bearer $accessToken")
+                parameter("after", afterEpoch)
+                parameter("per_page", 200)
+                parameter("page", page)
+            }.body<List<StravaActivity>>()
+
+            if (batch.isEmpty()) {
+                break
+            }
+
+            activities += batch
+
+            if (batch.size < 200) {
+                break
+            }
+
+            page += 1
+        }
+
+        return activities
+    }
+
+    private fun aggregateLeaderboardTotals(activities: List<StravaActivity>, activity: String): ActivityTotals {
+        val matchingActivities = activities.filter { matchesLeaderboardActivity(it.type, activity) }
+
+        return ActivityTotals(
+            count = matchingActivities.size,
+            distance = matchingActivities.sumOf { it.distance },
+            moving_time = matchingActivities.sumOf { it.moving_time },
+            elapsed_time = matchingActivities.sumOf { it.elapsed_time },
+            elevation_gain = matchingActivities.sumOf { it.total_elevation_gain },
+            achievement_count = matchingActivities.sumOf { it.achievement_count ?: 0 },
+        )
+    }
+
+    private fun leaderboardMetrics(activity: String, totals: ActivityTotals): LeaderboardMetrics {
+        return when (activity) {
+            "ride" -> LeaderboardMetrics(
+                primary_label = "distance_km",
+                primary_value = totals.distance / 1000.0,
+                secondary_label = "avg_speed_kph",
+                secondary_value = averageSpeedKph(totals.distance, totals.moving_time),
+                tertiary_label = "elevation_m",
+                tertiary_value = totals.elevation_gain,
+            )
+            "swim" -> LeaderboardMetrics(
+                primary_label = "distance_m",
+                primary_value = totals.distance,
+                secondary_label = "pace_per_100m_seconds",
+                secondary_value = pacePer100mSeconds(totals.distance, totals.moving_time),
+                tertiary_label = "sessions",
+                tertiary_value = totals.count.toDouble(),
+            )
+            else -> LeaderboardMetrics(
+                primary_label = "distance_km",
+                primary_value = totals.distance / 1000.0,
+                secondary_label = "pace_per_km_seconds",
+                secondary_value = pacePerKmSeconds(totals.distance, totals.moving_time),
+                tertiary_label = "elevation_m",
+                tertiary_value = totals.elevation_gain,
+            )
+        }
+    }
+
+    private fun aggregateMonthly(activities: List<StravaActivity>): MonthlySummary {
+        val today = LocalDate.now(ZoneOffset.UTC)
+        val months = (0..11)
+            .map { today.minusMonths(it.toLong()).withDayOfMonth(1) }
+            .sorted()
+
+        val aggregates = months.map { monthStart ->
+            val monthKey = monthStart.format(DateTimeFormatter.ofPattern("yyyy-MM"))
+            val items = activities.filter { activity ->
+                activity.start_date.startsWith(monthKey)
+            }
+            val runs = items.filter { it.type == "Run" }
+            val rides = items.filter { it.type == "Ride" }
+
+            MonthlyAggregate(
+                month = monthKey,
+                run_count = runs.size,
+                run_distance = runs.sumOf { it.distance },
+                run_moving_time = runs.sumOf { it.moving_time },
+                run_elevation_gain = runs.sumOf { it.total_elevation_gain },
+                ride_count = rides.size,
+                ride_distance = rides.sumOf { it.distance },
+                ride_moving_time = rides.sumOf { it.moving_time },
+                ride_elevation_gain = rides.sumOf { it.total_elevation_gain },
+                total_count = items.size,
+                total_distance = items.sumOf { it.distance },
+                total_moving_time = items.sumOf { it.moving_time },
+                total_elevation_gain = items.sumOf { it.total_elevation_gain },
+            )
+        }
+
+        return MonthlySummary(
+            months = aggregates.reversed(),
+            summary = MonthlySummaryTotals(
+                total_activities = aggregates.sumOf { it.total_count },
+                total_distance = aggregates.sumOf { it.total_distance },
+                total_moving_time = aggregates.sumOf { it.total_moving_time },
+                total_elevation_gain = aggregates.sumOf { it.total_elevation_gain },
+            ),
+        )
+    }
+
+    private fun athleteDisplayName(athlete: SignedUpAthlete): String {
+        val fullName = listOf(athlete.firstName, athlete.lastName)
+            .filter { it.isNotBlank() }
+            .joinToString(" ")
+        return if (fullName.isNotBlank()) fullName else "Athlete ${athlete.athleteId}"
+    }
+
+    private fun normalizeActivity(activity: String): String {
+        return when (activity.lowercase()) {
+            "ride", "cycling", "bike" -> "ride"
+            "swim", "swimming" -> "swim"
+            else -> "run"
+        }
+    }
+
+    private fun normalizePeriod(period: String): String {
+        return when (period.lowercase()) {
+            "7d", "7days", "week" -> "7d"
+            "30d", "30days", "month" -> "30d"
+            else -> "ytd"
+        }
+    }
+
+    private fun leaderboardStartDate(period: String): LocalDate {
+        val today = LocalDate.now(ZoneOffset.UTC)
+        return when (period) {
+            "7d" -> today.minusDays(6)
+            "30d" -> today.minusDays(29)
+            else -> today.withDayOfYear(1)
+        }
+    }
+
+    private fun matchesLeaderboardActivity(stravaType: String, activity: String): Boolean {
+        return when (activity) {
+            "ride" -> stravaType in setOf("Ride", "VirtualRide", "EBikeRide", "MountainBikeRide", "GravelRide")
+            "swim" -> stravaType in setOf("Swim")
+            else -> stravaType in setOf("Run", "TrailRun", "VirtualRun")
+        }
+    }
+
+    private fun averageSpeedKph(distanceMeters: Double, movingTimeSeconds: Int): Double {
+        if (distanceMeters <= 0.0 || movingTimeSeconds <= 0) {
+            return 0.0
+        }
+
+        return (distanceMeters / movingTimeSeconds) * 3.6
+    }
+
+    private fun pacePerKmSeconds(distanceMeters: Double, movingTimeSeconds: Int): Double {
+        if (distanceMeters <= 0.0 || movingTimeSeconds <= 0) {
+            return 0.0
+        }
+
+        return movingTimeSeconds / (distanceMeters / 1000.0)
+    }
+
+    private fun pacePer100mSeconds(distanceMeters: Double, movingTimeSeconds: Int): Double {
+        if (distanceMeters <= 0.0 || movingTimeSeconds <= 0) {
+            return 0.0
+        }
+
+        return movingTimeSeconds / (distanceMeters / 100.0)
+    }
+
+    private fun normalizePage(page: String): String {
+        return if (page == "strava") "strava" else "home"
+    }
+
+    private fun urlEncode(value: String): String = URLEncoder.encode(value, StandardCharsets.UTF_8)
+
+    @OptIn(ExperimentalEncodingApi::class)
+    private fun verifyState(state: String?): OAuthStatePayload {
+        if (state.isNullOrBlank()) {
+            return OAuthStatePayload(page = "home", issuedAtEpochSeconds = Instant.now().epochSecond)
+        }
+
+        val parts = state.split('.')
+        require(parts.size == 2) { "Invalid OAuth state" }
+        val payload = parts[0]
+        val signature = parts[1]
+        val expectedSignature = hmac(payload)
+        require(signature == expectedSignature) { "Invalid OAuth state signature" }
+
+        val decodedJson = Base64.UrlSafe.decode(payload).decodeToString()
+        val data = json.decodeFromString<OAuthStatePayload>(decodedJson)
+        val ageSeconds = max(0, Instant.now().epochSecond - data.issuedAtEpochSeconds)
+        require(ageSeconds <= 600) { "OAuth state expired" }
+        return data.copy(page = normalizePage(data.page))
+    }
+
+    @OptIn(ExperimentalEncodingApi::class)
+    private fun signState(data: OAuthStatePayload): String {
+        val payload = Base64.UrlSafe.encode(json.encodeToString(data).encodeToByteArray())
+        return "$payload.${hmac(payload)}"
+    }
+
+    private fun hmac(value: String): String {
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(config.stravaClientSecret.toByteArray(), "HmacSHA256"))
+        val digest = mac.doFinal(value.toByteArray())
+        return digest.joinToString(separator = "") { byte -> "%02x".format(byte) }
+    }
+}

--- a/src/main/kotlin/io/github/runtimeifi/services/StravaSignupStore.kt
+++ b/src/main/kotlin/io/github/runtimeifi/services/StravaSignupStore.kt
@@ -1,0 +1,63 @@
+package io.github.runtimeifi.services
+
+import io.github.runtimeifi.models.SignedUpAthlete
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
+import kotlin.io.path.moveTo
+import kotlin.io.path.pathString
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.json.Json
+
+class StravaSignupStore(
+    private val filePath: Path,
+    private val json: Json,
+) {
+    private val mutex = Mutex()
+    private val serializer = ListSerializer(SignedUpAthlete.serializer())
+
+    suspend fun getAll(): List<SignedUpAthlete> = mutex.withLock {
+        ensureFileExists()
+        json.decodeFromString(serializer, Files.readString(filePath))
+    }
+
+    suspend fun upsert(athlete: SignedUpAthlete) = mutex.withLock {
+        ensureFileExists()
+        val current = json.decodeFromString(serializer, Files.readString(filePath))
+        val updated = current
+            .filterNot { it.athleteId == athlete.athleteId } + athlete
+        val parent = filePath.parent
+        val tempFile = Files.createTempFile(parent, "strava-signup", ".tmp")
+
+        try {
+            Files.writeString(tempFile, json.encodeToString(serializer, updated.sortedBy { it.athleteId }))
+            try {
+                tempFile.moveTo(filePath, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING)
+            } catch (_: Exception) {
+                tempFile.moveTo(filePath, StandardCopyOption.REPLACE_EXISTING)
+            }
+        } catch (exception: Exception) {
+            Files.deleteIfExists(tempFile)
+            throw exception
+        }
+    }
+
+    private fun ensureFileExists() {
+        val parent = filePath.parent
+        if (parent != null && !parent.exists()) {
+            parent.createDirectories()
+        }
+
+        if (!filePath.exists()) {
+            Files.writeString(filePath, "[]")
+        }
+
+        require(Files.isRegularFile(filePath)) {
+            "Signup store path is not a file: ${filePath.pathString}"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Strava OAuth, signed cookie auth, local .env loading, and documented backend configuration for local development
- add leaderboard endpoints for run, ride, and swim across ytd, 30d, and 7d periods with activity-specific metrics
- keep existing Strava stats and club helper routes available while hardening config and token handling